### PR TITLE
feat: start a stopped queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,11 +397,9 @@ finishedChan := connection.StopAllConsuming()
 Wait on the `finishedChan` to wait for all consumers on all queues to finish.
 
 This is useful to implement a graceful shutdown of a consumer service. Please
-note that after calling `StopConsuming()` the queue might not be in a state
-where you can add consumers and call `StartConsuming()` again. If you have a
-use case where you actually need that sort of flexibility, please let us know.
-Currently for each queue you are only supposed to call `StartConsuming()` and
-`StopConsuming()` at most once.
+note that after calling `StopConsuming` the queue might be in a stopping state where
+you cannot add consumers and call `StartConsuming` again. You must wait until the queue is
+finished stopping, then you may call `StartConsuming` again and re-add your consumers.
 
 ### Return Rejected Deliveries
 


### PR DESCRIPTION
Add the ability to start a queue that has been stopped by resetting the queue settings and channels when finishing stopping the consuming.

The old consumers are removed when  you restart consuming,  so will need to be re-added after you've started the queue again.

You will be unable to add consumers back until the queue has finished stopping and you have started consumption again.